### PR TITLE
add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
The file `wss-wu-dryville.jpg` needs to be downloaded as part of this process, but it is too big to commit.